### PR TITLE
Remove redundant route from app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,6 @@ if ('development' == app.get('env')) {
   app.use(express.errorHandler());
 }
 
-app.get('/', routes.index);
 app.get('/partials/:name', routes.partials);
 app.get('*', routes.index);
 


### PR DESCRIPTION
#### What is this change?

Removed route mounted on `'/'`.
#### Why?

The [wildcard route](https://github.com/rhysr/angular-express-seed/blob/master/app.js#L31) is sufficient for rendering the index action. I don't believe the additional verbosity is beneficial here. Thoughts?

👀 Review: @rhysr 
